### PR TITLE
Account ID is the correct param. This was backwards in the Go lib

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -43,3 +43,6 @@
 
 6.1.1 August, 2018
   - Remove `FileURL` from structs.
+
+7.0.0 August, 2018
+  - Change `UserID` was deprecated in favor of `AccountID`, this was backwards in the Go lib

--- a/chargehound.go
+++ b/chargehound.go
@@ -11,7 +11,7 @@ const (
 	basepath   = "/v1/"
 	host       = "api.chargehound.com"
 	protocol   = "https://"
-	version    = "6.1.1"
+	version    = "7.0.0"
 
 	defaultHTTPTimeout = 60 * time.Second
 )

--- a/disputes.go
+++ b/disputes.go
@@ -75,7 +75,7 @@ type Dispute struct {
 	// The descriptor that appears on the customer's credit card statement for this change.
 	StatementDescriptor string `json:"statement_descriptor"`
 	// The account id for Connected accounts that are charged directly through Stripe (if any)
-	UserID string `json:"user_id"`
+	AccountID string `json:"account_id"`
 	// The kind for the dispute, 'chargeback', 'retrieval' or 'pre_arbitration'.
 	Kind string `json:"kind"`
 	// ISO 8601 timestamp.
@@ -159,8 +159,8 @@ type HTTPResponse struct {
 // Params for updating or submitting a dispute. See https://www.chargehound.com/docs/api/index.html#updating-a-dispute.
 type UpdateDisputeParams struct {
 	// The dispute id.
-	ID     string
-	UserID string
+	ID        string
+	AccountID string
 	// Id of the connected account for this dispute (if multiple accounts are connected)
 	Account      string
 	Force        bool
@@ -222,7 +222,7 @@ type CreateDisputeParams struct {
 	// List of products the customer purchased. (optional)
 	Products []Product `json:"products,omitempty"`
 	// Set the account id for Connected accounts that are charged directly through Stripe. (optional)
-	UserID string `json:"user_id,omitempty"`
+	AccountID string `json:"account_id,omitempty"`
 	// Set the kind for the dispute, 'chargeback', 'retrieval' or 'pre_arbitration'. (optional)
 	Kind string `json:"kind,omitempty"`
 	// Submit dispute evidence immediately after creation. (optional)
@@ -239,7 +239,7 @@ type updateDisputeBody struct {
 	Template     string                 `json:"template,omitempty"`
 	Charge       string                 `json:"charge,omitempty"`
 	Account      string                 `json:"account,omitempty"`
-	UserID       string                 `json:"user_id,omitempty"`
+	AccountID    string                 `json:"account_id,omitempty"`
 	ReferenceURL string                 `json:"reference_url,omitempty"`
 	Force        bool                   `json:"force,omitempty"`
 	Queue        bool                   `json:"queue,omitempty"`
@@ -368,7 +368,7 @@ func newUpdateDisputeBody(params *UpdateDisputeParams) (io.Reader, error) {
 		Products:     params.Products,
 		ReferenceURL: params.ReferenceURL,
 		Template:     params.Template,
-		UserID:       params.UserID,
+		AccountID:    params.AccountID,
 		Account:      params.Account,
 		Force:        params.Force,
 		Queue:        params.Queue,

--- a/disputes_test.go
+++ b/disputes_test.go
@@ -329,7 +329,7 @@ func TestUpdateDisputeUserID(t *testing.T) {
 			t.Error(err)
 		}
 
-		if b["user_id"] != "acct_xxx" {
+		if b["account_id"] != "acct_xxx" {
 			t.Error("Incorrect account id.")
 		}
 
@@ -350,8 +350,8 @@ func TestUpdateDisputeUserID(t *testing.T) {
 	ch.Protocol = url.Scheme + "://"
 
 	_, err = ch.Disputes.Update(&chargehound.UpdateDisputeParams{
-		ID:     "dp_xxx",
-		UserID: "acct_xxx",
+		ID:        "dp_xxx",
+		AccountID: "acct_xxx",
 	})
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
The account_id param should be used instead of the user_id param. At some point I got this backwards in a dyslexic moment, I went on to reuse the Go types in the Java SDK, so I repeated the mistake there.