### PR TITLE
Small type error fix

### DIFF
--- a/disputes.go
+++ b/disputes.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 )
 
 // Wrapper for the Chargehound API disputes resource.
@@ -363,7 +364,7 @@ func (dp *Disputes) List(params *ListDisputesParams) (*DisputeList, error) {
 	// map the query params to a dict
 	q := url.Values{}
 	if params.Limit > 0 {
-		q.Set("limit", string(params.Limit))
+		q.Set("limit", strconv.Itoa(params.Limit))
 	}
 
 	if params.StartingAfter != "" {


### PR DESCRIPTION
I found this error while calling `Disputes.List`, while passing in a Limit of 100. This was the error returned:

_Bad Request: Parameter 'limit' should be a integer. 'd' was provided._

Currently, the code in the `Disputes.List` function uses the built in `string` function, with an input of an integer to convert the limit. However, that returns the UTF-8 representation of the integer. For example, `string(100)` returns `d`. ` strconv.Itoa` will convert the integer 100 to the string "100", which is what I think was meant. :)