### PR TITLE
Adding major version as mentioned in go list command output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/chargehound/chargehound-go
+module github.com/chargehound/chargehound-go/v8
 
 go 1.16
 


### PR DESCRIPTION
Adding major version as mentioned in go list command output,

> pannepu@LM-MAA-40527599 chargehound-go % GOPROXY=proxy.golang.org go list -m github.com/chargehound/chargehound-go@v8.6.0
go list -m: github.com/chargehound/chargehound-go@v8.6.0: reading https://proxy.golang.org/github.com/chargehound/chargehound-go/@v/v8.6.0.info: 404 Not Found
        server response: not found: github.com/chargehound/chargehound-go@v8.6.0: invalid version: module contains a go.mod file, so module path must match major version ("github.com/chargehound/chargehound-go/v8")

This is not part of the deployment instructions and will update the documentation if it works.
