### PR TITLE
Updating go.mod file as suggested in the go list command output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,0 @@
-module github.com/chargehound/chargehound-go
-
-go 1.16
-

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/chargehound/chargehound-go/v8
+
+go 1.16
+
+require github.com/chargehound/chargehound-go v8.5.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/chargehound/chargehound-go v8.5.0+incompatible h1:bQ1qAeKmUejcUbEOFrG51Sm+8/oB9DEi8G/M2NYUBtg=
+github.com/chargehound/chargehound-go v8.5.0+incompatible/go.mod h1:oxaKQiiidu3dBq3lKfeCDogyqZAydg2ss5EjM6ux2Q0=


### PR DESCRIPTION
Updating go.mod file as suggested in the go list command output

```
pannepu@LM-MAA-40527599 chargehound-go % GOPROXY=proxy.golang.org go list -m github.com/chargehound/chargehound-go@v8.6.0
go list -m: github.com/chargehound/chargehound-go@v8.6.0: reading https://proxy.golang.org/github.com/chargehound/chargehound-go/@v/v8.6.0.info: 404 Not Found
server response: not found: github.com/chargehound/chargehound-go@v8.6.0: invalid version: module contains a go.mod file, so module path must match major version ("github.com/chargehound/chargehound-go/v8")
```